### PR TITLE
added getAccounts permission required for Android 5

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -21,6 +21,7 @@
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.READ_CONTACTS" />
             <uses-permission android:name="android.permission.WRITE_CONTACTS" />
+            <uses-permission android:name="android.permission.GET_ACCOUNTS" />
         </config-file>
 
         <source-file src="src/android/ContactsX.java" target-dir="src/de/einfachhans/ContactsX"/>


### PR DESCRIPTION
On Android 5 the app closed when trying to use the plugin. Thus, it was necessary to add permission to maintain compatibility with old devices.