### PR TITLE
(feat): add baseCountryCode option for normalizing phonenumbers

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <plugin id="cordova-plugin-contacts-x" version="2.0.3" xmlns="http://apache.org/cordova/ns/plugins/1.0">
     <name>ContactsX</name>
     <description>Cordova Plugins for managing contacts</description>
@@ -7,53 +7,50 @@
     <issue>https://github.com/EinfachHans/cordova-plugin-contacts-x/issues</issue>
 
     <license>MIT</license>
+	<js-module name="ContactsX" src="www/contactsX.js">
+		<clobbers target="window.ContactsX" />
+	</js-module>
+	<platform name="android">
+		<config-file parent="/*" target="res/xml/config.xml">
+			<feature name="ContactsX">
+				<param name="android-package" value="de.einfachhans.ContactsX.ContactsX" />
+			</feature>
+		</config-file>
+		<config-file target="AndroidManifest.xml" parent="/*">
+			<uses-permission android:name="android.permission.READ_CONTACTS" />
+			<uses-permission android:name="android.permission.WRITE_CONTACTS" />
+			<uses-permission android:name="android.permission.GET_ACCOUNTS" />
+		</config-file>
 
-    <js-module name="ContactsX" src="www/contactsX.js">
-        <clobbers target="window.ContactsX"/>
-    </js-module>
-    <platform name="android">
-        <config-file parent="/*" target="res/xml/config.xml">
-            <feature name="ContactsX">
-                <param name="android-package" value="de.einfachhans.ContactsX.ContactsX"/>
-            </feature>
-        </config-file>
-
-        <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.READ_CONTACTS" />
-            <uses-permission android:name="android.permission.WRITE_CONTACTS" />
-            <uses-permission android:name="android.permission.GET_ACCOUNTS" />
-        </config-file>
-        
-        <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
-
-        <source-file src="src/android/ContactsX.java" target-dir="src/de/einfachhans/ContactsX"/>
-        <source-file src="src/android/ContactsXErrorCodes.java" target-dir="src/de/einfachhans/ContactsX"/>
-        <source-file src="src/android/ContactsXFindOptions.java" target-dir="src/de/einfachhans/ContactsX"/>
-    </platform>
-    <platform name="ios">
-        <config-file parent="/*" target="config.xml">
-            <feature name="ContactsX">
-                <param name="ios-package" value="ContactsX"/>
-            </feature>
-        </config-file>
-        <header-file src="src/ios/ContactsX-Bridging-Header.h" />
-        <source-file src="src/ios/ContactsX.swift"  />
-        <source-file src="src/ios/ContactX.swift"  />
-        <source-file src="src/ios/ContactsXOptions.swift"  />
-
-        <podspec>
+		<framework src="src/android/build.gradle" custom="true" type="gradleReference" />
+		<source-file src="src/android/ContactsX.java" target-dir="src/de/einfachhans/ContactsX" />
+		<source-file src="src/android/ContactsXErrorCodes.java" target-dir="src/de/einfachhans/ContactsX" />
+		<source-file src="src/android/ContactsXFindOptions.java" target-dir="src/de/einfachhans/ContactsX" />
+	</platform>
+	<platform name="ios">
+		<config-file parent="/*" target="config.xml">
+			<feature name="ContactsX">
+				<param name="ios-package" value="ContactsX" />
+			</feature>
+		</config-file>
+		<header-file src="src/ios/ContactsX-Bridging-Header.h" />
+		<source-file src="src/ios/ContactsX.swift" />
+		<source-file src="src/ios/ContactX.swift" />
+		<source-file src="src/ios/ContactsXOptions.swift" />
+		<podspec>
 			<config>
 				<source url="https://github.com/CocoaPods/Specs.git" />
 			</config>
 			<pods use-frameworks="true">
-				<pod name="PhoneNumberKit" spec="~> 3.3"/>
+				<pod name="PhoneNumberKit" spec="~> 3.3" />
 			</pods>
 		</podspec>
-
-        <config-file target="*-Info.plist" parent="NSContactsUsageDescription">
-            <string>This app requires access to the contacts to manage them.</string>
-        </config-file>
-
-        <dependency id="cordova-plugin-add-swift-support" version="2.0.2"/>
-    </platform>
+		<config-file target="*-Info.plist" parent="NSContactsUsageDescription">
+			<string>
+				This app requires access to the contacts to manage them.
+			</string>
+		</config-file>
+		
+        <dependency id="cordova-plugin-add-swift-support" version="2.0.2" />
+	</platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -23,6 +23,8 @@
             <uses-permission android:name="android.permission.WRITE_CONTACTS" />
             <uses-permission android:name="android.permission.GET_ACCOUNTS" />
         </config-file>
+        
+        <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
 
         <source-file src="src/android/ContactsX.java" target-dir="src/de/einfachhans/ContactsX"/>
         <source-file src="src/android/ContactsXErrorCodes.java" target-dir="src/de/einfachhans/ContactsX"/>
@@ -38,6 +40,15 @@
         <source-file src="src/ios/ContactsX.swift"  />
         <source-file src="src/ios/ContactX.swift"  />
         <source-file src="src/ios/ContactsXOptions.swift"  />
+
+        <podspec>
+			<config>
+				<source url="https://github.com/CocoaPods/Specs.git" />
+			</config>
+			<pods use-frameworks="true">
+				<pod name="PhoneNumberKit" spec="~> 3.3"/>
+			</pods>
+		</podspec>
 
         <config-file target="*-Info.plist" parent="NSContactsUsageDescription">
             <string>This app requires access to the contacts to manage them.</string>

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ Please consider donating if you're using this plugin in an app that makes you mo
 
 ## Android
 
-For normalization Android the plugin implements [Google - libphonenumber](https://github.com/google/libphonenumber) 
+For normalization the plugin implements [Google - libphonenumber](https://github.com/google/libphonenumber) 
 
 ## iOS
 
@@ -114,7 +114,7 @@ They can be accessed over `window.ContactsX.ErrorCodes` and are present in the T
 
 ## Normalization E.164
 
-If `baseCountryCode` is passed as an option to the [find](#find) method, the plugin attempts to resolve the normalized phone numbers in E.164 format. Setting a wrong (ISO 3166-1 alpha-2) value would cause the libary to not be able to (correctly) resolve the normalized number. Typically the value should correspond to the device (sim) country.
+If `baseCountryCode` is passed as an option to the [find](#find) method, the plugin attempts to resolve the normalized phone numbers in E.164 format. Setting a wrong (ISO 3166-1 alpha-2) value would cause the libary to not be able to (correctly) resolve the normalized number. Typically the value should correspond to the device (SIM) country.
 
 #### Output example
 Assuming that the device is from the "Netherlands", the correct `baseCountryCode` would be `"NL"`. 
@@ -202,7 +202,7 @@ Same SuccessType as **hasPermission()**
 
 ## find
 
-Find Contacts by given options. If you don't set a field to `true`, it is not included or empty in the result. If `baseCountryCode` is passed as an option, the plugin attempts to resolve the normalized E.164 phone numbers in the `phoneNumbers` Array. 
+Find Contacts by given options. If you don't set a field in `fields` to `true`, it is not included or empty in the result. When `baseCountryCode` is defined (using a valid [ISO 3166-1 alpha 2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) code), the plugin attempts to resolve the normalized E.164 phone numbers in the `phoneNumbers` Array.
 
 ### Parameters:
 
@@ -216,7 +216,7 @@ Find Contacts by given options. If you don't set a field to `true`, it is not in
         - familyName (boolean) - *default: true*
         - phoneNumbers (boolean)
         - emails (boolean)
-    - baseCountryCode : *default: null (3166-1 alpha-2 countrycode)*    
+    - baseCountryCode (string) - *default: null*    
 
 ```js
 window.ContactsX.find(function(success) {

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ Please consider donating if you're using this plugin in an app that makes you mo
 - [Usage](#usage)
   - [Failure Callbacks](#failure-callbacks)
   - [Error Codes](#error-codes)
+  - [Normalization E.164](#normalization-e164)
 - [Api](#api)
   - [hasPermission](#haspermission)
   - [requestPermission](#requestpermission)
@@ -55,11 +56,15 @@ Please consider donating if you're using this plugin in an app that makes you mo
 
 ## Android
 
+For normalization Android the plugin implements [Google - libphonenumber](https://github.com/google/libphonenumber) 
+
 ## iOS
 
 This Plugin is developed in Swift and automaticaly adds the Plugin to [Support Swift](https://github.com/akofman/cordova-plugin-add-swift-support).
 
 I developed it, testing with **cordova-ios@6.1.0**.
+
+For normalization on iOS the plugin implements [marmelroy - PhoneNumberKit](https://github.com/marmelroy/PhoneNumberKit)
 
 # Environment Variables
 
@@ -106,6 +111,22 @@ The following Error Codes can be fired by this Plugin:
 - UnknownError
 
 They can be accessed over `window.ContactsX.ErrorCodes` and are present in the TypeScript definition too of course. 
+
+## Normalization E.164
+
+If `baseCountryCode` is passed as an option to the [find](#find) method, the plugin attempts to resolve the normalized phone numbers in E.164 format. Setting a wrong (ISO 3166-1 alpha-2) value would cause the libary to not be able to (correctly) resolve the normalized number. Typically the value should correspond to the device (sim) country.
+
+#### Output example
+Assuming that the device is from the "Netherlands", the correct `baseCountryCode` would be `"NL"`. 
+
+| `baseCountryCode`:| `"NL"`       | `"US"`       | `""`|
+|-------------------|--------------|--------------|-----|
+| +49 151 12345     | +4915112345  | +4915112345" |  "" |
+| (06) 123 4567     | +3161234567  | ""           |  "" |
+| +1 (424) 555-1234 | +14245551234 | +14245551234 |  "" |
+| +31 (0) 6 987 654 | +316987654   | +316987654   |  "" |
+
+*For context the "nationalNumber" of the Netherlands is "+31"*
 
 # Api
 
@@ -181,7 +202,7 @@ Same SuccessType as **hasPermission()**
 
 ## find
 
-Find Contacts by given options. If you don't set a field to true, it is not included or empty in the result
+Find Contacts by given options. If you don't set a field to `true`, it is not included or empty in the result. If `baseCountryCode` is passed as an option, the plugin attempts to resolve the normalized E.164 phone numbers in the `phoneNumbers` Array. 
 
 ### Parameters:
 
@@ -195,6 +216,7 @@ Find Contacts by given options. If you don't set a field to true, it is not incl
         - familyName (boolean) - *default: true*
         - phoneNumbers (boolean)
         - emails (boolean)
+    - baseCountryCode : *default: null (3166-1 alpha-2 countrycode)*    
 
 ```js
 window.ContactsX.find(function(success) {
@@ -204,7 +226,8 @@ window.ContactsX.find(function(success) {
 }, {
   fields: {
     phoneNumbers: true
-  }
+  },
+  baseCountryCode : 'GB'
 });
 ```
 
@@ -298,6 +321,7 @@ window.ContactsX.delete("some_id",
 
 ## ContactXPhoneNumber
 - id (string)
+- normalized (string) *if baseCountryCode is set/valid*
 - type (string)
 - value (string)
 

--- a/src/android/ContactsX.java
+++ b/src/android/ContactsX.java
@@ -15,6 +15,10 @@ import android.net.Uri;
 import android.os.RemoteException;
 import android.provider.ContactsContract;
 
+import com.google.i18n.phonenumbers.NumberParseException;
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
+import com.google.i18n.phonenumbers.Phonenumber;
+
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CallbackContext;
 
@@ -44,6 +48,8 @@ public class ContactsX extends CordovaPlugin {
 
     public static final int REQ_CODE_PERMISSIONS = 0;
     public static final int REQ_CODE_PICK = 2;
+
+    private PhoneNumberUtil phoneUtil = PhoneNumberUtil.getInstance();
 
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) {
@@ -251,7 +257,7 @@ public class ContactsX extends CordovaPlugin {
                 switch (mimeType) {
                     case ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE:
                         JSONArray jsPhoneNumbers = jsContact.getJSONArray("phoneNumbers");
-                        jsPhoneNumbers.put(phoneQuery(contactsCursor));
+                        jsPhoneNumbers.put(phoneQuery(contactsCursor, options));
                         break;
                     case ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE:
                         JSONArray emailAddresses = jsContact.getJSONArray("emails");
@@ -285,13 +291,16 @@ public class ContactsX extends CordovaPlugin {
         return jsContacts;
     }
 
-    private JSONObject phoneQuery(Cursor cursor) throws JSONException {
+    private JSONObject phoneQuery(Cursor cursor, ContactsXFindOptions options) throws JSONException {
         JSONObject phoneNumber = new JSONObject();
         int typeCode = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.TYPE));
         String typeLabel = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.LABEL));
         String type = (typeCode == ContactsContract.CommonDataKinds.Phone.TYPE_CUSTOM) ? typeLabel : getPhoneType(typeCode);
         phoneNumber.put("id", cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone._ID)));
         phoneNumber.put("value", cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER)));
+        phoneNumber.put("normalized", getNormalizedPhoneNumber(
+                                                cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER)),
+                                                options));
         phoneNumber.put("type", type);
         return phoneNumber;
     }
@@ -312,6 +321,19 @@ public class ContactsX extends CordovaPlugin {
             Intent contactPickerIntent = new Intent(Intent.ACTION_PICK, ContactsContract.Contacts.CONTENT_URI);
             this.cordova.startActivityForResult(this, contactPickerIntent, REQ_CODE_PICK);
         });
+    }
+
+    private String getNormalizedPhoneNumber(String phoneNumber, ContactsXFindOptions options){
+
+        if(options.baseCountryCode != null && phoneNumber != null){
+            try {
+                Phonenumber.PhoneNumber phoneNumberProto = phoneUtil.parse(phoneNumber, options.baseCountryCode);
+                return phoneUtil.format(phoneNumberProto, PhoneNumberUtil.PhoneNumberFormat.E164);
+            } catch (NumberParseException e) {
+                return "";
+            }
+        }
+        return "";
     }
 
     private JSONObject getContactById(String id) {

--- a/src/android/ContactsXFindOptions.java
+++ b/src/android/ContactsXFindOptions.java
@@ -4,6 +4,8 @@ import org.json.JSONObject;
 
 public class ContactsXFindOptions {
 
+    String baseCountryCode = null;
+    
     boolean displayName = true;
     boolean firstName = true;
     boolean middleName = true;
@@ -17,6 +19,12 @@ public class ContactsXFindOptions {
 
             if(fields != null) {
                 this.parseFields(fields);
+            }
+
+            String baseCountryCode = options.optString("baseCountryCode", null);
+
+            if(baseCountryCode != null){
+                this.baseCountryCode = baseCountryCode;
             }
         }
     }

--- a/src/android/ContactsXFindOptions.java
+++ b/src/android/ContactsXFindOptions.java
@@ -3,8 +3,6 @@ package de.einfachhans.ContactsX;
 import org.json.JSONObject;
 
 public class ContactsXFindOptions {
-
-    String baseCountryCode = null;
     
     boolean displayName = true;
     boolean firstName = true;
@@ -12,6 +10,7 @@ public class ContactsXFindOptions {
     boolean familyName = true;
     boolean phoneNumbers;
     boolean emails;
+    String baseCountryCode = null;
 
     public ContactsXFindOptions(JSONObject options) {
         if (options != null) {

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,0 +1,42 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.4.1'
+    }
+}
+
+repositories {
+    mavenCentral()
+    maven {
+        url "https://maven.google.com"
+    }
+}
+
+
+dependencies {
+    compile 'com.googlecode.libphonenumber:libphonenumber:8.2.0'
+}
+
+android {
+    defaultConfig {
+        minSdkVersion 12
+        targetSdkVersion 22
+        multiDexEnabled true
+        applicationId "your_package_name"
+    }
+
+    buildTypes {
+        debug {
+            minifyEnabled false
+        }
+        release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -26,7 +26,6 @@ android {
         minSdkVersion 12
         targetSdkVersion 22
         multiDexEnabled true
-        applicationId "your_package_name"
     }
 
     buildTypes {

--- a/src/ios/ContactX.swift
+++ b/src/ios/ContactX.swift
@@ -4,9 +4,9 @@ class ContactX {
 
     var contact: CNContact;
     var options: ContactsXOptions;
-
+    
     init(contact: CNContact, options: ContactsXOptions) {
-        self.contact = contact
+        self.contact = contact;
         self.options = options;
     }
 
@@ -26,6 +26,7 @@ class ContactX {
             return [
                 "id": ob.identifier,
                 "type": ContactsX.mapLabelToString(label: ob.label ?? ""),
+                "normalized" : self.getNormalizedPhoneNumber(phoneNumberString: ob.value.stringValue),
                 "value": ob.value.stringValue
             ]
         }
@@ -61,5 +62,19 @@ class ContactX {
         }
 
         return result as NSDictionary;
+    }
+    
+    private func getNormalizedPhoneNumber(phoneNumberString: String) -> String {
+        if(phoneNumberString != "" && self.options.baseCountryCode != nil){
+            do {
+                let phoneNumberCustomDefaultRegion = try ContactsX.getPhoneNumberKitInstance().parse(phoneNumberString, withRegion: self.options.baseCountryCode!!, ignoreType: true);
+                
+                return ContactsX.getPhoneNumberKitInstance().format(phoneNumberCustomDefaultRegion, toType : .e164);
+            }
+            catch {
+                return "";
+            }
+        }
+        return "";
     }
 }

--- a/src/ios/ContactsX.swift
+++ b/src/ios/ContactsX.swift
@@ -1,9 +1,11 @@
 import Contacts
 import ContactsUI
+import PhoneNumberKit
 
 @objc(ContactsX) class ContactsX : CDVPlugin, CNContactPickerDelegate {
 
     var _callbackId: String?
+    static var _PhoneNumberKitInstance: PhoneNumberKit? = nil;
 
     @objc(pluginInitialize)
     override func pluginInitialize() {
@@ -376,6 +378,13 @@ import ContactsUI
         default:
             return "other";
         }
+    }
+    
+    static func getPhoneNumberKitInstance() -> PhoneNumberKit {
+        if(ContactsX._PhoneNumberKitInstance == nil){
+            ContactsX._PhoneNumberKitInstance = PhoneNumberKit();
+        }
+        return ContactsX._PhoneNumberKitInstance!;
     }
 }
 

--- a/src/ios/ContactsXOptions.swift
+++ b/src/ios/ContactsXOptions.swift
@@ -5,13 +5,20 @@ class ContactsXOptions {
     var familyName: Bool = true;
     var phoneNumbers: Bool = false;
     var emails: Bool = false;
+    var baseCountryCode : String?? = nil;
 
     init(options: NSDictionary?) {
         if(options != nil) {
-            let fields = options?.value(forKey: "fields") as? NSDictionary ?? nil;
 
+            let fields = options?.value(forKey: "fields") as? NSDictionary ?? nil;
             if(fields != nil) {
                 self.parseFields(fields: fields!)
+            }
+
+            let baseCountryCode = options?.value(forKey: "baseCountryCode") as? String ?? nil;
+            
+            if(baseCountryCode != nil) {
+                self.baseCountryCode = baseCountryCode;
             }
         }
     }


### PR DESCRIPTION
Adds `baseCountryCode` option, when it is defined the (E.164) normalized phonenumbers are resolved.

### Usage
```javascript
window.ContactsX.find(function(success) {
  console.log(success);
}, function (error) {
  console.error(error);
}, {
  fields: {
    phoneNumbers: true
  },
  baseCountryCode : 'DE' // ISO 3166-1 alpha-2 
});
```

```json
[
    {
        "id": "1",
        "rawId": "1",
        "displayName": "Test",
        "phoneNumbers": [
            {
                "id": "1",
                "value": "+31 6 1234567",
                "normalized": "+3161234567",
                "type": "mobile"
            },
            {
                "id": "2",
                "value": "0 151 12345",
                "normalized": "+4915112345",
                "type": "home"
            }
        ],
        "emails": [],
        "firstName": "Test "
    }
]

```

### Implements/uses:
- Android  [Google - libphonenumber](https://github.com/google/libphonenumber) 
- iOS [marmelroy - PhoneNumberKit](https://github.com/marmelroy/PhoneNumberKit)

### Reason

Having native code implement/run complicated libraries seemed (more) efficient.  The reason for implementing this here is because Android used to return the [NORMALIZED_NUMBER](https://developer.android.com/reference/android/provider/ContactsContract.CommonDataKinds.Phone.html#NORMALIZED_NUMBER).  But it does not anymore and taking it further with E.164 has advantages. 

### Other

I do not have a strong opinion if this functionality belongs here perse, it might be nice to have. But there are certainly arguments against it. Feel free to ignore/close this PR/proposal.