### PR TITLE
bug: Hotfix - Release w/ minifyEnabled using proguard removes WebView (#23)

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -33,7 +33,7 @@ android {
             minifyEnabled false
         }
         release {
-            minifyEnabled true
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }


### PR DESCRIPTION
The release stage minifies the files using proguard, however this removes WebView [[1]](https://github.com/MichaelRocks/libphonenumber-android/blob/master/sample/proguard-rules.pro)

And there is currently no eloquent way [[2]](https://stackoverflow.com/questions/41900434/minifyenabled-causing-app-to-crash-on-release-mode) (found) to adjust the proguard files from a cordova plugin.

Since this issue did not appear in the test release, I find proguard to be somewhat unreliable. 
There might be a solution, but for now this is a hotfix until a more eloquent way is found.
