### PR TITLE
feat: replace compile dependency configuration with implementation

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -18,7 +18,7 @@ repositories {
 
 
 dependencies {
-    compile 'com.googlecode.libphonenumber:libphonenumber:8.2.0'
+    implementation 'com.googlecode.libphonenumber:libphonenumber:8.2.0'
 }
 
 android {


### PR DESCRIPTION
During the migration to [Cordova Android 11.0.0](https://cordova.apache.org/announcements/2022/07/12/cordova-android-release-11.0.0.html) I was forced to upgrade to Gradle 7, which is not compatible with this plugin. As far as I know, the `compile` dependency configuration has been removed in Gradle 7. Instead we should use `implementation`.