### PR TITLE
fix(ios): nil check on adding mail address

### DIFF
--- a/src/ios/ContactsX.swift
+++ b/src/ios/ContactsX.swift
@@ -214,7 +214,7 @@ import PhoneNumberKit
                 var newMails: [CNLabeledValue<NSString>] = [];
                 outer: for newMail in contact.emails! {
                     for mail in editContact.emailAddresses {
-                        if(mail.identifier == newMail.id!) {
+                        if(newMail.id != nil && mail.identifier == newMail.id!) {
                             newMails.append(mail.settingLabel(ContactsX.mapStringToLabel(string: newMail.type), value: newMail.value as NSString));
                             continue outer;
                         }


### PR DESCRIPTION
If a new mail address is added to an existing contact, `nil` is unexpectedly evaluated.

```
Fatal error: Unexpectedly found nil while unwrapping an Optional value
```

I'm not an expert in Swift. But as this problem does not occur with phone numbers. I've compared the code and added the necessary `nil` check. Afterwards the problem is gone.

It would be great, if you would merge this little fix. 

Thank you very much in advance!