### PR TITLE
fix(ios): declare error codes enum within main class

### DIFF
--- a/src/ios/ContactsX.swift
+++ b/src/ios/ContactsX.swift
@@ -395,11 +395,11 @@ import PhoneNumberKit
         }
         return ContactsX._PhoneNumberKitInstance!;
     }
-}
 
-enum ErrorCodes:NSNumber {
-    case UnsupportedAction = 1
-    case WrongJsonObject = 2
-    case PermissionDenied = 3
-    case UnknownError = 10
+    enum ErrorCodes:NSNumber {
+        case UnsupportedAction = 1
+        case WrongJsonObject = 2
+        case PermissionDenied = 3
+        case UnknownError = 10
+    }
 }


### PR DESCRIPTION
If the plugin is used together with "cordova-plugin-advanced-imagepicker", Xcode throws

```
Invalid redeclaration of 'ErrorCodes'
```

As stated in my previous PR - I'm not an expert with Swift and therefore not sure, if this is a proper fix - but the error is gone with this little modification.

It would be great, if you can take a look at this issue / fix.

Best regards!

PS: I've posted the [same PR for the imagepicker plugin](https://github.com/EinfachHans/cordova-plugin-advanced-imagepicker/pull/54).